### PR TITLE
Add opt.mkdirpAsync call into recurseDir function

### DIFF
--- a/copy.js
+++ b/copy.js
@@ -122,6 +122,7 @@ function copyItem (from, to, opts) {
 
 function recurseDir (from, to, opts) {
   validate('SSO', [from, to, opts])
+  opts.mkdirpAsync = promisify(opts.Promise, mkdirp)
   var recurseWith = opts.recurseWith || copyItem
   var fs = opts.fs || nodeFs
   var chown = opts.chown || promisify(Promise, fs.chown)


### PR DESCRIPTION
Add opt.mkdirpAsync call into recurseDir function to allow for async copies in folders. Addresses issue https://github.com/npm/copy-concurrently/issues/1.